### PR TITLE
feat: prepare for first release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,7 +105,7 @@ release:
     scanfrog --json grype-output.json
     ```
     
-    **Full Changelog**: https://github.com/luhring/scanfrog/compare/{{ .PreviousTag }}...{{ .Tag }}
+    {{ if .PreviousTag }}**Full Changelog**: https://github.com/luhring/scanfrog/compare/{{ .PreviousTag }}...{{ .Tag }}{{ else }}**Initial Release**: This is the first release of Scanfrog! 🎉{{ end }}
 
   # Prefer to release as draft first
   draft: true

--- a/cmd/scanfrog/main.go
+++ b/cmd/scanfrog/main.go
@@ -11,7 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const devVersion = "dev"
+
 var (
+	// Version information set by goreleaser during build
+	version = devVersion
+	commit  = "none"
+	date    = "unknown"
+
 	jsonFile string
 	rootCmd  = &cobra.Command{
 		Use:   "scanfrog [image]",
@@ -24,10 +31,23 @@ using Grype and rendered with Bubble Tea.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runGame,
 	}
+
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Printf("scanfrog version %s\n", version)
+			if version != devVersion {
+				fmt.Printf("  commit: %s\n", commit)
+				fmt.Printf("  built:  %s\n", date)
+			}
+		},
+	}
 )
 
 func init() {
 	rootCmd.Flags().StringVar(&jsonFile, "json", "", "Path to pre-existing Grype JSON file")
+	rootCmd.AddCommand(versionCmd)
 }
 
 func main() {


### PR DESCRIPTION
- Add version variables to main.go for GoReleaser ldflags injection
- Add version command to display build information
- Fix .goreleaser.yml to handle missing PreviousTag on first release
- Use const for devVersion to avoid magic strings

These changes ensure the release workflow will work correctly for the initial v0.1.0 release and embed proper version information in binaries.

🤖 Generated with [Claude Code](https://claude.ai/code)